### PR TITLE
Tweak modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3711,15 +3711,6 @@
           "dev": true,
           "optional": true
         },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3728,6 +3719,15 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -8041,15 +8041,6 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -8102,6 +8093,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
       }
     },
     "strip-ansi": {

--- a/src/__tests__/context.js
+++ b/src/__tests__/context.js
@@ -2,7 +2,7 @@
 
 import React from "react";
 import renderer from "react-test-renderer";
-import { Consumer, Provider } from "../context";
+import { Consumer, Provider } from "../";
 
 const render = v => renderer.create(v).toJSON();
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { Consumer, Layer, Manager, Provider } from "..";
+import { Consumer, Layer, Manager, Provider } from "../";
 
 test("exports", () => {
   expect(typeof Consumer).toBe("object");

--- a/src/__tests__/layer.js
+++ b/src/__tests__/layer.js
@@ -1,6 +1,6 @@
 // @flow
 
-import Layer from "../layer";
+import { Layer } from "../";
 
 test("Layer", () => {
   expect(typeof Layer).toBe("function");

--- a/src/context.js
+++ b/src/context.js
@@ -1,7 +1,6 @@
 // @flow
 
-import type { PortalRef } from "./types";
-
 import { createContext } from "react";
+import type { PortalRef } from "./types";
 
 export const { Consumer, Provider } = createContext((null: PortalRef));

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 // @flow
 
 export * from "./context";
-export { default as Layer } from "./layer";
-export { default as Manager } from "./manager";
+export { Layer } from "./layer";
+export { Manager } from "./manager";

--- a/src/layer.js
+++ b/src/layer.js
@@ -1,17 +1,16 @@
 // @flow
 
-import type { Node } from "react";
 import type { PortalRef } from "./types";
 
-import React from "react";
+import * as React from "react";
 import { createPortal } from "react-dom";
 import { Consumer } from "./context";
 
 type Props = {
-  children: ?Node
+  children: ?React.Node
 };
 
-export default ({ children }: Props) => (
+export const Layer = ({ children }: Props) => (
   <Consumer>
     {(portalRef: PortalRef) =>
       portalRef ? createPortal(children, portalRef) : null

--- a/src/manager.js
+++ b/src/manager.js
@@ -1,14 +1,13 @@
 // @flow
 
-import type { Node } from "react";
 import type { PortalRef } from "./types";
 
-import React, { Component } from "react";
+import * as React from "react";
 import { createPortal } from "react-dom";
 import { Provider } from "./context";
 
 type Props = {
-  children: Node,
+  children: React.Node,
   zIndex: number
 };
 
@@ -16,7 +15,7 @@ type State = {
   portalRef: PortalRef
 };
 
-export default class extends Component<Props, State> {
+export class Manager extends React.Component<Props, State> {
   static defaultProps = {
     zIndex: 1000
   };


### PR DESCRIPTION
Ref https://github.com/treshugart/react-layer-context/issues/1

Changed default exports to named ones with debuggable names.

Imported react as namespace. This is how react will look in v18
(discussed with Dan Abramov). It's better to start follow this in
examples/tutorials/documentations/tweets.